### PR TITLE
[SUN-887] Initial joint values are read when the hardware interface starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+***
+> **NOTE**: Sunrise robotics has forked the original package and made changes to support their needs.
+> This mainly revolves around adding support for 1) Omnicore controllers and 2) starting the controller
+> with initial joint values.
+>
+> These changes are manifested in the change of the dependecies (abb_egm_rws_managers) and the way
+> the initial joint values are retrieved from the controller in the hardware interface. A standalone
+> function was added to retrieve the joint values from RWS but without the use of the RWS managers.
+> This is a temporary solution and we will try to help with merging the changes upstream.
+***
+
 This is a meta-package containing everything to run an ABB robot or simulation with ROS 2.
 
 - `abb_bringup`: Launch files and ros2_control config files that are generic to many types of ABB robots.
@@ -9,7 +20,7 @@ This is a meta-package containing everything to run an ABB robot or simulation w
 - `robot_studio_resources`: Code and a pack-and-go solution to begin using RobotStudio easily.
 - `abb_ros2`: A meta-package that exists to reserve the repo name in rosdistro
 
-## Getting Started:
+
 
 There are three ways to use this package:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-***
-> **NOTE**: Sunrise robotics has forked the original package and made changes to support their needs.
+> [!NOTE]
+> Sunrise robotics has forked the original package and made changes to support their needs.
 > This mainly revolves around adding support for 1) Omnicore controllers and 2) starting the controller
 > with initial joint values.
 >
@@ -7,7 +7,6 @@
 > the initial joint values are retrieved from the controller in the hardware interface. A standalone
 > function was added to retrieve the joint values from RWS but without the use of the RWS managers.
 > This is a temporary solution and we will try to help with merging the changes upstream.
-***
 
 This is a meta-package containing everything to run an ABB robot or simulation with ROS 2.
 

--- a/abb.repos
+++ b/abb.repos
@@ -9,8 +9,8 @@ repositories:
     version: master
   abb_egm_rws_managers:
     type: git
-    url: https://github.com/ros-industrial/abb_egm_rws_managers.git
-    version: master
+    url: https://github.com/Yadunund/abb_egm_rws_managers.git
+    version: yadu/support_initial_joint_values
   abb_ros2_msgs:
     type: git
     url: https://github.com/gbartyzel/abb_ros2_msgs.git

--- a/abb_hardware_interface/CMakeLists.txt
+++ b/abb_hardware_interface/CMakeLists.txt
@@ -26,6 +26,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     rclcpp_lifecycle
 )
 
+# Add Poco and TinyXML2 to dependencies
+find_package(Poco REQUIRED Foundation Net NetSSL XML)
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 
@@ -42,6 +45,13 @@ add_library(
   SHARED
   src/abb_hardware_interface.cpp
   src/utilities.cpp
+)
+# Add Poco and TinyXML2 to target dependencies
+target_link_libraries(${PROJECT_NAME}
+  Poco::Foundation
+  Poco::Net
+  Poco::NetSSL
+  Poco::XML
 )
 ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_include_directories(

--- a/abb_hardware_interface/include/abb_hardware_interface/abb_hardware_interface.hpp
+++ b/abb_hardware_interface/include/abb_hardware_interface/abb_hardware_interface.hpp
@@ -64,6 +64,9 @@ public:
   ROS2_CONTROL_DRIVER_PUBLIC
   return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
+  ROS2_CONTROL_DRIVER_PUBLIC
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
 private:
   // EGM
   abb::robot::RobotControllerDescription robot_controller_description_;
@@ -71,6 +74,10 @@ private:
 
   // Store the state and commands for the robot(s)
   abb::robot::MotionData motion_data_;
+
+  rclcpp::Clock clock_;  // Clock for throttling logs
+
+  bool is_activated_;
 };
 
 }  // namespace abb_hardware_interface

--- a/abb_hardware_interface/include/abb_hardware_interface/utilities.hpp
+++ b/abb_hardware_interface/include/abb_hardware_interface/utilities.hpp
@@ -88,7 +88,7 @@ void verifyRobotWareVersion(const RobotWareVersion& rw_version);
  */
 bool verifyStateMachineAddInPresence(const SystemIndicators& system_indicators);
 
-std::vector<abb::robot::InitialJointValue> getInitialJointsFromController(
+std::vector<abb::robot::InitialJointValue> getRWSJointsFromController(
     const std::string& ip, const int port);
 
 /**

--- a/abb_hardware_interface/include/abb_hardware_interface/utilities.hpp
+++ b/abb_hardware_interface/include/abb_hardware_interface/utilities.hpp
@@ -87,6 +87,19 @@ void verifyRobotWareVersion(const RobotWareVersion& rw_version);
  * \return bool true if the StateMachine Add-In is present.
  */
 bool verifyStateMachineAddInPresence(const SystemIndicators& system_indicators);
+
+std::vector<abb::robot::InitialJointValue> getInitialJointsFromController(
+    const std::string& ip, const int port);
+
+/**
+ * \brief A function for getting initial joint values from the controller using RWS.
+ *
+ * \param ip for the IP address of the controller.
+ * \param port for the port number of the controller.
+ *
+ * \return std::vector<abb::robot::InitialJointValue> containing the initial joint values.
+ */
+
 }  // namespace utilities
 }  // namespace robot
 }  // namespace abb

--- a/abb_hardware_interface/src/abb_hardware_interface.cpp
+++ b/abb_hardware_interface/src/abb_hardware_interface.cpp
@@ -373,7 +373,7 @@ CallbackReturn ABBSystemHardware::on_deactivate(const rclcpp_lifecycle::State& /
 return_type ABBSystemHardware::read(const rclcpp::Time& time, const rclcpp::Duration& period)
 {
   egm_manager_->read(motion_data_);
-  RCLCPP_INFO_THROTTLE(LOGGER, clock_, 1000, "Reading from robot");
+  RCLCPP_DEBUG_THROTTLE(LOGGER, clock_, 1000, "Reading from robot");
   return return_type::OK;
 }
 
@@ -381,7 +381,7 @@ return_type ABBSystemHardware::write(const rclcpp::Time& time, const rclcpp::Dur
 {
   if (!is_activated_)
   {
-    RCLCPP_INFO_THROTTLE(LOGGER, clock_, 1000, "Not activated. Skipping write");
+    RCLCPP_WARN_THROTTLE(LOGGER, clock_, 1000, "Not activated. Skipping write");
     return return_type::OK;
   }
 
@@ -396,7 +396,7 @@ return_type ABBSystemHardware::write(const rclcpp::Time& time, const rclcpp::Dur
     }
   }
 
-  RCLCPP_INFO_THROTTLE(LOGGER, clock_, 1000, "Writing to robot");
+  RCLCPP_DEBUG_THROTTLE(LOGGER, clock_, 1000, "Writing to robot");
   egm_manager_->write(motion_data_);
   return return_type::OK;
 }

--- a/abb_hardware_interface/src/abb_hardware_interface.cpp
+++ b/abb_hardware_interface/src/abb_hardware_interface.cpp
@@ -15,6 +15,8 @@
 
 #include <abb_hardware_interface/abb_hardware_interface.hpp>
 #include <abb_hardware_interface/utilities.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <future>
 
 using namespace std::chrono_literals;
 
@@ -29,6 +31,10 @@ CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo
   {
     return CallbackReturn::ERROR;
   }
+
+  // Define the initial joints variable
+  // std::vector<abb::robot::InitialJointValue> initial_joint_values = {};
+  std::vector<abb::robot::InitialJointValue> initial_joint_values;
 
   // Validate interfaces configured in ros2_control xacro.
   for (const hardware_interface::ComponentInfo& joint : info_.joints)
@@ -84,11 +90,11 @@ CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo
                                  configure_it->second == "false" || configure_it->second == "False" ? false :
                                                                                                       true;
 
+  const auto rws_port = stoi(info_.hardware_parameters["rws_port"]);
+  const auto rws_ip = info_.hardware_parameters["rws_ip"];
   if (configure_via_rws)
   {
     RCLCPP_INFO_STREAM(LOGGER, "Generating robot controller description from RWS.");
-    const auto rws_port = stoi(info_.hardware_parameters["rws_port"]);
-    const auto rws_ip = info_.hardware_parameters["rws_ip"];
 
     if (rws_ip == "None")
     {
@@ -160,18 +166,99 @@ CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo
   RCLCPP_INFO_STREAM(LOGGER, "Robot controller description:\n"
                                  << abb::robot::summaryText(robot_controller_description_));
 
+  abb::robot::InitialJointValue initial_value;
+
+  /*
+  // TIMO: The fix below is rather hacky and I personally don't like it. We subscribe to the
+  // joints acquired from RWS which means, that the `abb_joint_publisher` must be running.
+  // This solution is not great and a different one should be found.
+  // For the time being I leave this here in a commit so I don't have to re-write in case I need it again.
+  // Create a promise and future to wait for the message
+  std::promise<void> promise;
+  std::future<void> future = promise.get_future();
+
+  //
+  // Subscribe to the topic called `/rws_joint_states` to get the current joint values
+  rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("abb_hardware_interface");
+  auto subscription = node->create_subscription<sensor_msgs::msg::JointState>(
+    "/rws_joint_states", 10,
+    [this, &promise, &initial_value, &initial_joint_values](const sensor_msgs::msg::JointState::SharedPtr msg) {
+      // Update the motion data with the new joint values, position and velocity
+      for (size_t i = 0; i < msg->name.size(); ++i) {
+        initial_value.position_state = msg->position[i];
+        initial_value.velocity_state = 0;
+        initial_value.position_command = msg->position[i];
+        initial_value.velocity_command = 0;
+        // Print the name and the value of the position
+        initial_joint_values.push_back(std::move(initial_value));
+      }
+      // Signal that we received the message
+      promise.set_value();
+    });
+
+  RCLCPP_INFO(LOGGER, "Waiting for initial joint states...");
+
+  // Spin until we get a message or timeout
+  rclcpp::Rate rate(10);  // 10Hz
+  int timeout_seconds = 10;  // Timeout after 10 seconds
+  int count = 0;
+
+  while (rclcpp::ok()) {
+    rclcpp::spin_some(node);
+
+    // Check if we received the message
+    if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+      RCLCPP_INFO(LOGGER, "Received initial joint states");
+      break;
+    }
+
+    rate.sleep();
+    count++;
+
+    if (count > timeout_seconds * 10) {  // 10Hz * 10 seconds = 100 iterations
+      RCLCPP_ERROR(LOGGER, "Timeout waiting for initial joint states");
+      return CallbackReturn::ERROR;
+    }
+  }
+
+
+  // Reset the subscription since we don't need it anymore
+  subscription.reset();
+  */
+
+  // Get initial joint values from controller using RWS and our custom function
+  try
+  {
+    RCLCPP_INFO(LOGGER, "Getting initial joint values from controller...");
+    initial_joint_values = abb::robot::utilities::getRWSJointsFromController(rws_ip, rws_port);
+    RCLCPP_INFO(LOGGER, "Successfully retrieved initial joint values");
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Failed to get initial joint values: " << e.what());
+    return CallbackReturn::ERROR;
+  }
+
   // Configure EGM
   RCLCPP_INFO(LOGGER, "Configuring EGM interface...");
 
   // Initialize motion data from robot controller description
   try
   {
-    abb::robot::initializeMotionData(motion_data_, robot_controller_description_);
+    //abb::robot::initializeMotionData(motion_data_, robot_controller_description_);
+    abb::robot::initializeMotionData(motion_data_, robot_controller_description_, initial_joint_values);
   }
   catch (...)
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Failed to initialize motion data from robot controller description");
     return CallbackReturn::ERROR;
+  }
+
+  // Loop through the joints and print the current joint values
+  for (const auto& joint : motion_data_.groups[0].units[0].joints)
+  {
+    RCLCPP_INFO_STREAM(LOGGER, "Joint state " << joint.name << " has position " << joint.state.position << " and velocity " << joint.state.velocity);
+    RCLCPP_INFO_STREAM(LOGGER, "Joint command " << joint.name << " has position " << joint.command.position << " and velocity " << joint.command.velocity);
   }
 
   // Create channel configuration for each mechanical unit group
@@ -182,7 +269,7 @@ CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo
     {
       const auto egm_port = stoi(info_.hardware_parameters[group.name() + "egm_port"]);
       const auto channel_configuration =
-          abb::robot::EGMManager::ChannelConfiguration{ static_cast<uint16_t>(egm_port), group };
+          abb::robot::EGMManager::ChannelConfiguration{ static_cast<uint16_t>(egm_port), "", group };
       channel_configurations.emplace_back(channel_configuration);
       RCLCPP_INFO_STREAM(LOGGER,
                          "Configuring EGM for mechanical unit group " << group.name() << " on port " << egm_port);
@@ -202,6 +289,16 @@ CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Failed to initialize EGM connection");
     return CallbackReturn::ERROR;
+  }
+
+  try
+  {
+    // Try to read the current values from the robot
+    egm_manager_->read(motion_data_);
+  }
+  catch(const std::exception& e)
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Failed to read the current values from the robot");
   }
 
   return CallbackReturn::SUCCESS;
@@ -252,6 +349,8 @@ std::vector<hardware_interface::CommandInterface> ABBSystemHardware::export_comm
 CallbackReturn ABBSystemHardware::on_activate(const rclcpp_lifecycle::State& /* previous_state */)
 {
   size_t counter = 0;
+  std::vector<abb::robot::InitialJointValue> initial_joint_values;
+
   RCLCPP_INFO(LOGGER, "Connecting to robot...");
   while (rclcpp::ok() && ++counter < NUM_CONNECTION_TRIES)
   {
@@ -271,7 +370,41 @@ CallbackReturn ABBSystemHardware::on_activate(const rclcpp_lifecycle::State& /* 
     rclcpp::sleep_for(500ms);
   }
 
+  // Print the joint current and command values from motion_data_
+  for (const auto& joint : motion_data_.groups[0].units[0].joints)
+  {
+    RCLCPP_INFO_STREAM(LOGGER, "Joint state " << joint.name << " has position " << joint.state.position << " and velocity " << joint.state.velocity);
+    RCLCPP_INFO_STREAM(LOGGER, "Joint command " << joint.name << " has position " << joint.command.position << " and velocity " << joint.command.velocity);
+  }
+
   egm_manager_->read(motion_data_);
+
+  // Get initial joint values from controller using RWS and our custom function
+  try
+  {
+    RCLCPP_INFO(LOGGER, "Getting initial joint values from controller...");
+    initial_joint_values = abb::robot::utilities::getInitialJointsFromController(info_.hardware_parameters["rws_ip"], stoi(info_.hardware_parameters["rws_port"]));
+    RCLCPP_INFO(LOGGER, "Successfully retrieved initial joint values");
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Failed to get initial joint values: " << e.what());
+    return CallbackReturn::ERROR;
+  }
+
+  // Assign the initial joint values to the motion_data_
+  for (size_t i = 0; i < initial_joint_values.size(); ++i)
+  {
+    motion_data_.groups[0].units[0].joints[i].state.position = initial_joint_values[i].position_state;
+    motion_data_.groups[0].units[0].joints[i].state.velocity = initial_joint_values[i].velocity_state;
+  }
+
+  // Print the joint values from motion_data_
+  for (const auto& joint : motion_data_.groups[0].units[0].joints)
+  {
+    RCLCPP_INFO_STREAM(LOGGER, "Joint state " << joint.name << " has position " << joint.state.position << " and velocity " << joint.state.velocity);
+    RCLCPP_INFO_STREAM(LOGGER, "Joint command " << joint.name << " has position " << joint.command.position << " and velocity " << joint.command.velocity);
+  }
 
   RCLCPP_INFO(LOGGER, "ros2_control hardware interface was successfully started!");
 

--- a/abb_hardware_interface/src/abb_hardware_interface.cpp
+++ b/abb_hardware_interface/src/abb_hardware_interface.cpp
@@ -168,64 +168,6 @@ CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo
 
   abb::robot::InitialJointValue initial_value;
 
-  /*
-  // TIMO: The fix below is rather hacky and I personally don't like it. We subscribe to the
-  // joints acquired from RWS which means, that the `abb_joint_publisher` must be running.
-  // This solution is not great and a different one should be found.
-  // For the time being I leave this here in a commit so I don't have to re-write in case I need it again.
-  // Create a promise and future to wait for the message
-  std::promise<void> promise;
-  std::future<void> future = promise.get_future();
-
-  //
-  // Subscribe to the topic called `/rws_joint_states` to get the current joint values
-  rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("abb_hardware_interface");
-  auto subscription = node->create_subscription<sensor_msgs::msg::JointState>(
-    "/rws_joint_states", 10,
-    [this, &promise, &initial_value, &initial_joint_values](const sensor_msgs::msg::JointState::SharedPtr msg) {
-      // Update the motion data with the new joint values, position and velocity
-      for (size_t i = 0; i < msg->name.size(); ++i) {
-        initial_value.position_state = msg->position[i];
-        initial_value.velocity_state = 0;
-        initial_value.position_command = msg->position[i];
-        initial_value.velocity_command = 0;
-        // Print the name and the value of the position
-        initial_joint_values.push_back(std::move(initial_value));
-      }
-      // Signal that we received the message
-      promise.set_value();
-    });
-
-  RCLCPP_INFO(LOGGER, "Waiting for initial joint states...");
-
-  // Spin until we get a message or timeout
-  rclcpp::Rate rate(10);  // 10Hz
-  int timeout_seconds = 10;  // Timeout after 10 seconds
-  int count = 0;
-
-  while (rclcpp::ok()) {
-    rclcpp::spin_some(node);
-
-    // Check if we received the message
-    if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-      RCLCPP_INFO(LOGGER, "Received initial joint states");
-      break;
-    }
-
-    rate.sleep();
-    count++;
-
-    if (count > timeout_seconds * 10) {  // 10Hz * 10 seconds = 100 iterations
-      RCLCPP_ERROR(LOGGER, "Timeout waiting for initial joint states");
-      return CallbackReturn::ERROR;
-    }
-  }
-
-
-  // Reset the subscription since we don't need it anymore
-  subscription.reset();
-  */
-
   // Get initial joint values from controller using RWS and our custom function
   try
   {
@@ -349,7 +291,6 @@ std::vector<hardware_interface::CommandInterface> ABBSystemHardware::export_comm
 CallbackReturn ABBSystemHardware::on_activate(const rclcpp_lifecycle::State& /* previous_state */)
 {
   size_t counter = 0;
-  std::vector<abb::robot::InitialJointValue> initial_joint_values;
 
   RCLCPP_INFO(LOGGER, "Connecting to robot...");
   while (rclcpp::ok() && ++counter < NUM_CONNECTION_TRIES)
@@ -370,41 +311,7 @@ CallbackReturn ABBSystemHardware::on_activate(const rclcpp_lifecycle::State& /* 
     rclcpp::sleep_for(500ms);
   }
 
-  // Print the joint current and command values from motion_data_
-  for (const auto& joint : motion_data_.groups[0].units[0].joints)
-  {
-    RCLCPP_INFO_STREAM(LOGGER, "Joint state " << joint.name << " has position " << joint.state.position << " and velocity " << joint.state.velocity);
-    RCLCPP_INFO_STREAM(LOGGER, "Joint command " << joint.name << " has position " << joint.command.position << " and velocity " << joint.command.velocity);
-  }
-
   egm_manager_->read(motion_data_);
-
-  // Get initial joint values from controller using RWS and our custom function
-  try
-  {
-    RCLCPP_INFO(LOGGER, "Getting initial joint values from controller...");
-    initial_joint_values = abb::robot::utilities::getInitialJointsFromController(info_.hardware_parameters["rws_ip"], stoi(info_.hardware_parameters["rws_port"]));
-    RCLCPP_INFO(LOGGER, "Successfully retrieved initial joint values");
-  }
-  catch (const std::exception& e)
-  {
-    RCLCPP_ERROR_STREAM(LOGGER, "Failed to get initial joint values: " << e.what());
-    return CallbackReturn::ERROR;
-  }
-
-  // Assign the initial joint values to the motion_data_
-  for (size_t i = 0; i < initial_joint_values.size(); ++i)
-  {
-    motion_data_.groups[0].units[0].joints[i].state.position = initial_joint_values[i].position_state;
-    motion_data_.groups[0].units[0].joints[i].state.velocity = initial_joint_values[i].velocity_state;
-  }
-
-  // Print the joint values from motion_data_
-  for (const auto& joint : motion_data_.groups[0].units[0].joints)
-  {
-    RCLCPP_INFO_STREAM(LOGGER, "Joint state " << joint.name << " has position " << joint.state.position << " and velocity " << joint.state.velocity);
-    RCLCPP_INFO_STREAM(LOGGER, "Joint command " << joint.name << " has position " << joint.command.position << " and velocity " << joint.command.velocity);
-  }
 
   RCLCPP_INFO(LOGGER, "ros2_control hardware interface was successfully started!");
 

--- a/abb_hardware_interface/src/abb_hardware_interface.cpp
+++ b/abb_hardware_interface/src/abb_hardware_interface.cpp
@@ -32,6 +32,9 @@ CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo
     return CallbackReturn::ERROR;
   }
 
+  // Initialize the is_activated_ flag
+  is_activated_ = false;
+
   // Define the initial joints variable
   // std::vector<abb::robot::InitialJointValue> initial_joint_values = {};
   std::vector<abb::robot::InitialJointValue> initial_joint_values;
@@ -89,6 +92,9 @@ CallbackReturn ABBSystemHardware::on_init(const hardware_interface::HardwareInfo
   const bool configure_via_rws = configure_it == info_.hardware_parameters.end()                    ? true :
                                  configure_it->second == "false" || configure_it->second == "False" ? false :
                                                                                                       true;
+
+  // Initialize a clock so that we can throttle the logging
+  clock_ = rclcpp::Clock(RCL_ROS_TIME);
 
   const auto rws_port = stoi(info_.hardware_parameters["rws_port"]);
   const auto rws_ip = info_.hardware_parameters["rws_ip"];
@@ -291,6 +297,7 @@ std::vector<hardware_interface::CommandInterface> ABBSystemHardware::export_comm
 CallbackReturn ABBSystemHardware::on_activate(const rclcpp_lifecycle::State& /* previous_state */)
 {
   size_t counter = 0;
+  std::vector<abb::robot::InitialJointValue> initial_joint_values;
 
   RCLCPP_INFO(LOGGER, "Connecting to robot...");
   while (rclcpp::ok() && ++counter < NUM_CONNECTION_TRIES)
@@ -311,21 +318,85 @@ CallbackReturn ABBSystemHardware::on_activate(const rclcpp_lifecycle::State& /* 
     rclcpp::sleep_for(500ms);
   }
 
+  // Print the joint current and command values from motion_data_
+  for (const auto& joint : motion_data_.groups[0].units[0].joints)
+  {
+    RCLCPP_DEBUG_STREAM(LOGGER, "Joint state " << joint.name << " has position " << joint.state.position << " and velocity " << joint.state.velocity);
+    RCLCPP_DEBUG_STREAM(LOGGER, "Joint command " << joint.name << " has position " << joint.command.position << " and velocity " << joint.command.velocity);
+  }
+
   egm_manager_->read(motion_data_);
+
+  // Get initial joint values from controller using RWS and our custom function
+  try
+  {
+    RCLCPP_DEBUG(LOGGER, "Getting initial joint values from controller...");
+    initial_joint_values = abb::robot::utilities::getRWSJointsFromController(info_.hardware_parameters["rws_ip"], stoi(info_.hardware_parameters["rws_port"]));
+    RCLCPP_DEBUG(LOGGER, "Successfully retrieved initial joint values");
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Failed to get initial joint values: " << e.what());
+    return CallbackReturn::ERROR;
+  }
+
+  // Assign the initial joint values to the motion_data_
+  for (size_t i = 0; i < initial_joint_values.size(); ++i)
+  {
+    motion_data_.groups[0].units[0].joints[i].state.position = initial_joint_values[i].position_state;
+    motion_data_.groups[0].units[0].joints[i].state.velocity = initial_joint_values[i].velocity_state;
+    motion_data_.groups[0].units[0].joints[i].command.position = initial_joint_values[i].position_command;
+    motion_data_.groups[0].units[0].joints[i].command.velocity = initial_joint_values[i].velocity_command;
+  }
+
+  // Print the joint values from motion_data_
+  for (const auto& joint : motion_data_.groups[0].units[0].joints)
+  {
+    RCLCPP_DEBUG_STREAM(LOGGER, "Joint state " << joint.name << " has position " << joint.state.position << " and velocity " << joint.state.velocity);
+    RCLCPP_DEBUG_STREAM(LOGGER, "Joint command " << joint.name << " has position " << joint.command.position << " and velocity " << joint.command.velocity);
+  }
+
+  is_activated_ = true;
 
   RCLCPP_INFO(LOGGER, "ros2_control hardware interface was successfully started!");
 
   return CallbackReturn::SUCCESS;
 }
 
+CallbackReturn ABBSystemHardware::on_deactivate(const rclcpp_lifecycle::State& /* previous_state */)
+{
+  RCLCPP_INFO(LOGGER, "ros2_control hardware interface was successfully stopped!");
+  is_activated_ = false;
+  return CallbackReturn::SUCCESS;
+}
+
 return_type ABBSystemHardware::read(const rclcpp::Time& time, const rclcpp::Duration& period)
 {
   egm_manager_->read(motion_data_);
+  RCLCPP_INFO_THROTTLE(LOGGER, clock_, 1000, "Reading from robot");
   return return_type::OK;
 }
 
 return_type ABBSystemHardware::write(const rclcpp::Time& time, const rclcpp::Duration& period)
 {
+  if (!is_activated_)
+  {
+    RCLCPP_INFO_THROTTLE(LOGGER, clock_, 1000, "Not activated. Skipping write");
+    return return_type::OK;
+  }
+
+  // Ensure that there is not a too big difference between the current and the desired joint values
+  for (auto& joint : motion_data_.groups[0].units[0].joints)
+  {
+    if (std::abs(joint.command.position - joint.state.position) > 0.05)
+    {
+      RCLCPP_WARN_THROTTLE(LOGGER, clock_, 1000, "Too big diff in joint %s. Skipping write", joint.name.c_str());
+      // We are not returning ERROR because that would trigger a cleanup and restart and we don't want that
+      return return_type::OK;
+    }
+  }
+
+  RCLCPP_INFO_THROTTLE(LOGGER, clock_, 1000, "Writing to robot");
   egm_manager_->write(motion_data_);
   return return_type::OK;
 }

--- a/abb_hardware_interface/src/utilities.cpp
+++ b/abb_hardware_interface/src/utilities.cpp
@@ -134,7 +134,7 @@ bool verifyStateMachineAddInPresence(const SystemIndicators& system_indicators)
   return system_indicators.addins().state_machine_1_0() || system_indicators.addins().state_machine_1_1();
 }
 
-// This function works as "stand-alone" does not make any use of the RWS managers. That is because
+// This function works as "stand-alone" and does not make any use of the RWS managers. That is because
 // the RWS managers (in their current state) are not compatible with the Omnicore controllers. The
 // primary use of this function is to allow the hardware interface to retrieve the current joint
 // values from the controller before EGM is initialized. This prevents sudden jumps in the joint

--- a/abb_hardware_interface/src/utilities.cpp
+++ b/abb_hardware_interface/src/utilities.cpp
@@ -42,6 +42,24 @@
 #include <abb_hardware_interface/utilities.hpp>
 #include <stdexcept>
 
+// New includes
+#include <Poco/Net/HTTPSClientSession.h>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/URI.h>
+#include <Poco/DOM/DOMParser.h>
+#include <Poco/DOM/Document.h>
+#include <Poco/DOM/NodeList.h>
+#include <Poco/DOM/Element.h>
+#include <sstream>
+#include <vector>
+#include <cmath>
+#include <Poco/Net/AcceptCertificateHandler.h>
+#include <Poco/Net/SSLManager.h>
+#include <Poco/Net/Context.h>
+#include <Poco/Base64Encoder.h>
+// End of new includes
+
 #include <rclcpp/rclcpp.hpp>
 
 namespace abb
@@ -115,6 +133,139 @@ bool verifyStateMachineAddInPresence(const SystemIndicators& system_indicators)
 {
   return system_indicators.addins().state_machine_1_0() || system_indicators.addins().state_machine_1_1();
 }
+
+// This function works as "stand-alone" does not make any use of the RWS managers. That is because
+// the RWS managers (in their current state) are not compatible with the Omnicore controllers. The
+// primary use of this function is to allow the hardware interface to retrieve the current joint
+// values from the controller before EGM is initialized. This prevents sudden jumps in the joint
+// states which would otherwise occur when starting the hardware interface.
+std::vector<abb::robot::InitialJointValue> getRWSJointsFromController(
+    const std::string& ip, const int port)
+{
+    std::vector<abb::robot::InitialJointValue> initial_joints;
+
+    try {
+        // Set up SSL context to accept all certificates
+        Poco::Net::Context::Ptr context = new Poco::Net::Context(
+            Poco::Net::Context::CLIENT_USE, "", "", "",
+            Poco::Net::Context::VERIFY_NONE, 9, false,
+            "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+
+        // Create a certificate handler that accepts all certificates
+        Poco::SharedPtr<Poco::Net::InvalidCertificateHandler> ptrHandler =
+            new Poco::Net::AcceptCertificateHandler(false);
+
+        // Install the custom certificate handler
+        Poco::Net::SSLManager::instance().initializeClient(nullptr, ptrHandler, context);
+
+        // Construct the URL and create session
+        Poco::URI uri("https://" + ip + ":" + std::to_string(port) +
+                     "/rw/motionsystem/mechunits/ROB_1/jointtarget");
+
+        // Create session with the custom context
+        Poco::Net::HTTPSClientSession session(uri.getHost(), uri.getPort(), context);
+        session.setKeepAlive(true);
+
+        // Create and send request with authentication
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, uri.getPathAndQuery());
+
+        // Add Accept header
+        request.set("Accept", "application/xhtml+xml;v=2.0");
+
+        // Add Basic Authentication
+        std::string auth = "Default User:robotics";
+        std::ostringstream encodedAuth;
+        Poco::Base64Encoder encoder(encodedAuth);
+        encoder << auth;
+        encoder.close();
+        request.setCredentials("Basic", encodedAuth.str());
+
+        session.sendRequest(request);
+
+        // Get response
+        Poco::Net::HTTPResponse response;
+        std::istream& rs = session.receiveResponse(response);
+
+        if (response.getStatus() != Poco::Net::HTTPResponse::HTTP_OK) {
+            throw std::runtime_error("HTTP request failed with status: " +
+                std::to_string(response.getStatus()));
+        }
+
+        // Read the response
+        std::stringstream ss;
+        ss << rs.rdbuf();
+        std::string response_string = ss.str();
+
+        // Parse XML response using Poco::XML
+        Poco::XML::DOMParser parser;
+        Poco::AutoPtr<Poco::XML::Document> doc = parser.parseString(response_string);
+
+        // Navigate to the li element with class "ms-jointtarget"
+        Poco::XML::Element* root = doc->documentElement();
+        if (!root) {
+            throw std::runtime_error("Failed to find root element in XML");
+        }
+
+        // Find the li element with class "ms-jointtarget"
+        Poco::XML::Element* body = root->getChildElement("body");
+        if (!body) {
+            throw std::runtime_error("Failed to find body element");
+        }
+
+        Poco::XML::Element* div = body->getChildElement("div");
+        if (!div) {
+            throw std::runtime_error("Failed to find div element");
+        }
+
+        Poco::XML::Element* ul = div->getChildElement("ul");
+        if (!ul) {
+            throw std::runtime_error("Failed to find ul element");
+        }
+
+        Poco::XML::Element* li = ul->getChildElement("li");
+        if (!li) {
+            throw std::runtime_error("Failed to find li element");
+        }
+
+        // Extract joint values
+        for (int i = 1; i <= 6; ++i) {
+            std::string joint_name = "rax_" + std::to_string(i);
+
+            // Get all span elements
+            Poco::XML::NodeList* spans = li->getElementsByTagName("span");
+            Poco::XML::Element* joint_elem = nullptr;
+
+            // Find the span with the matching class
+            for (unsigned long i = 0; i < spans->length(); ++i) {
+                Poco::XML::Element* span = static_cast<Poco::XML::Element*>(spans->item(i));
+                if (span->getAttribute("class") == joint_name) {
+                    joint_elem = span;
+                    break;
+                }
+            }
+
+            if (!joint_elem) {
+                throw std::runtime_error("Failed to find " + joint_name + " in XML");
+            }
+
+            InitialJointValue initial_value;
+            initial_value.position_state = std::stod(joint_elem->innerText()) * M_PI / 180.0;
+            initial_value.velocity_state = 0;
+            initial_value.position_command = std::stod(joint_elem->innerText()) * M_PI / 180.0;
+            initial_value.velocity_command = 0;
+            initial_joints.push_back(initial_value);
+
+            // Release the NodeList
+            spans->release();
+        }
+    }
+    catch (const Poco::Exception& e) {
+        throw std::runtime_error("Poco error: " + std::string(e.what()));
+    }
+
+    return initial_joints;
+}
+
 }  // namespace utilities
 }  // namespace robot
 }  // namespace abb

--- a/abb_hardware_interface/src/utilities.cpp
+++ b/abb_hardware_interface/src/utilities.cpp
@@ -203,28 +203,28 @@ std::vector<abb::robot::InitialJointValue> getRWSJointsFromController(
         // Navigate to the li element with class "ms-jointtarget"
         Poco::XML::Element* root = doc->documentElement();
         if (!root) {
-            throw std::runtime_error("Failed to find root element in XML");
+            throw std::runtime_error("Failed to find root element in XML.");
         }
 
         // Find the li element with class "ms-jointtarget"
         Poco::XML::Element* body = root->getChildElement("body");
         if (!body) {
-            throw std::runtime_error("Failed to find body element");
+            throw std::runtime_error("Failed to find body element.");
         }
 
         Poco::XML::Element* div = body->getChildElement("div");
         if (!div) {
-            throw std::runtime_error("Failed to find div element");
+            throw std::runtime_error("Failed to find div element.");
         }
 
         Poco::XML::Element* ul = div->getChildElement("ul");
         if (!ul) {
-            throw std::runtime_error("Failed to find ul element");
+            throw std::runtime_error("Failed to find ul element.");
         }
 
         Poco::XML::Element* li = ul->getChildElement("li");
         if (!li) {
-            throw std::runtime_error("Failed to find li element");
+            throw std::runtime_error("Failed to find li element.");
         }
 
         // Extract joint values
@@ -245,7 +245,7 @@ std::vector<abb::robot::InitialJointValue> getRWSJointsFromController(
             }
 
             if (!joint_elem) {
-                throw std::runtime_error("Failed to find " + joint_name + " in XML");
+                throw std::runtime_error("Failed to find " + joint_name + " in XML.");
             }
 
             InitialJointValue initial_value;


### PR DESCRIPTION
# Description

This PR adds code that reads joint state values from RWS before the hardware interface is started. It is important to note that the code introduced here does not make use of the existing RWS managers that would be available vie `abb_librws` because those are incompatible with RWS2.0. For the sake of not complicating things, I added a simple method that makes the HTTP GET request to the correct address to retrieve the joint values.

Some reading material regarding the issue:
- [Robot arm goes to zero position the moment ros2_control is started](https://github.com/PickNikRobotics/abb_ros2/issues/44)
- [Add support for RWS 2.0](https://github.com/ros-industrial/abb_librws/issues/147)

# Test plan

The test plan revolves mainly around making sure everything builds. The functionality will be tested by me on the real robot. Some additional changes might come into place after the test are done. However, the bulk of the work is here.

# Checklist for Reviewers

Reviewer 1: @fgrcar 
Reviewer 2: @JenniferBuehler 

Before a PR to this repo can get approved and merged, the following needs to be checked by both reviewers:

- The test plan was executed and verified by:
    - [ ] Reviewer 1
    - [ ] Reviewer 2
- Documentation added, function/classes headers clean?
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Has the `README.md` been updated, or not required?
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Has the `CHANGELOG` been updated?
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Have unit tests been added where needed?
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Any testing not covered by unit tests was done manually by the reviewers.
    - [ ] Reviewer 1
    - [ ] Reviewer 2
- Version ticks in `package.xml`, `CMakeLists.txt` and/or `setup.py` were made.
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Licensing updates were added, or not required.
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- New dependencies added to `requirements.txt`, `setup.py` and `package.xml` - or: not applicable.
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check

