### PR TITLE
[SUN-1930] Make lttng optional at build time

### DIFF
--- a/abb_hardware_interface/CMakeLists.txt
+++ b/abb_hardware_interface/CMakeLists.txt
@@ -54,16 +54,26 @@ include_directories(
 ## Build ##
 ###########
 
+# Define source files
+set(SOURCE_FILES
+  src/abb_hardware_interface.cpp
+  src/utilities.cpp
+)
+
+# Conditionally add tracepoint source file when tracing is enabled
+if(ENABLE_TRACING)
+  list(APPEND SOURCE_FILES src/hardware_interface_tp.c)
+  add_compile_definitions(TRACING_ENABLED)
+endif()
+
 add_library(
   ${PROJECT_NAME}
   SHARED
-  src/abb_hardware_interface.cpp
-  src/utilities.cpp
-  src/hardware_interface_tp.c  # Include the generated tracepoint source file
+  ${SOURCE_FILES}
 )
 
 if(ENABLE_TRACING)
-  target_compile_definitions(abb_hardware_interface PRIVATE TRACING_ENABLED)
+  # target_compile_definitions removed
 endif()
 
   # Add Poco and TinyXML2 to target dependencies

--- a/abb_hardware_interface/CMakeLists.txt
+++ b/abb_hardware_interface/CMakeLists.txt
@@ -30,7 +30,32 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Add Poco and TinyXML2 to dependencies
-find_package(Poco REQUIRED Foundation Net NetSSL XML)
+# Find Poco components manually
+find_path(POCO_INCLUDE_DIRS Poco/Poco.h)
+find_library(POCO_FOUNDATION_LIB PocoFoundation)
+find_library(POCO_NET_LIB PocoNet)
+find_library(POCO_NETSSL_LIB PocoNetSSL)
+find_library(POCO_XML_LIB PocoXML)
+find_library(POCO_UTIL_LIB PocoUtil)
+find_library(POCO_JSON_LIB PocoJSON)
+
+# Check if all libraries were found
+if(NOT POCO_FOUNDATION_LIB OR NOT POCO_NET_LIB OR NOT POCO_NETSSL_LIB)
+  message(FATAL_ERROR "Required Poco libraries not found")
+endif()
+
+# Optional libraries - don't fail if not found
+if(NOT POCO_XML_LIB)
+  message(WARNING "Poco XML library not found, some functionality may be disabled")
+endif()
+
+if(NOT POCO_JSON_LIB)
+  message(WARNING "Poco JSON library not found, some functionality may be disabled")
+endif()
+
+if(NOT POCO_UTIL_LIB)
+  message(WARNING "Poco Util library not found, some functionality may be disabled")
+endif()
 
 # Find dependencies
 find_package(ament_cmake REQUIRED)
@@ -72,24 +97,23 @@ add_library(
   ${SOURCE_FILES}
 )
 
-if(ENABLE_TRACING)
-  # target_compile_definitions removed
-endif()
-
-  # Add Poco and TinyXML2 to target dependencies
+# Add Poco and TinyXML2 to target dependencies
 target_link_libraries(${PROJECT_NAME}
-  Poco::Foundation
-  Poco::Net
-  Poco::NetSSL
-  Poco::XML
+  ${POCO_FOUNDATION_LIB}
+  ${POCO_NET_LIB}
+  ${POCO_NETSSL_LIB}
+  ${POCO_XML_LIB}
+  ${POCO_UTIL_LIB}
+  ${POCO_JSON_LIB}
   lttng-ust  # Add the LTTng UST library
 )
-ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_include_directories(
   ${PROJECT_NAME}
   PRIVATE
   include
+  ${POCO_INCLUDE_DIRS}
 )
+ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 pluginlib_export_plugin_description_file(hardware_interface abb_hardware_interface.xml)
 

--- a/abb_hardware_interface/CMakeLists.txt
+++ b/abb_hardware_interface/CMakeLists.txt
@@ -105,8 +105,14 @@ target_link_libraries(${PROJECT_NAME}
   ${POCO_XML_LIB}
   ${POCO_UTIL_LIB}
   ${POCO_JSON_LIB}
-  lttng-ust  # Add the LTTng UST library
 )
+
+# Conditionally link against LTTng-UST library when tracing is enabled
+if(ENABLE_TRACING)
+  target_link_libraries(${PROJECT_NAME} lttng-ust)
+endif()
+
+
 target_include_directories(
   ${PROJECT_NAME}
   PRIVATE

--- a/abb_hardware_interface/src/abb_hardware_interface.cpp
+++ b/abb_hardware_interface/src/abb_hardware_interface.cpp
@@ -19,7 +19,9 @@
 #include <future>
 
 // Tracing
+#ifdef TRACING_ENABLED
 # include "abb_hardware_interface/hardware_interface_tp.h"
+#endif
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
# Description

Filip noted that the `abb_ros2` package fails to build. This is due to some dependencies that I introduced in my previous work that allowed us to run tracing. These dependencies are set as optional by properly using the `TRACING_ENABLED` build variable

# Test plan

I will prepare a dockerfile to test this along with the other PR

# Checklist for Reviewers

1 - Filip
2 - Jennifer

Before a PR to this repo can get approved and merged, the following needs to be checked by both reviewers:

- The test plan was executed and verified by:
    - [ ] Reviewer 1
    - [ ] Reviewer 2
- Documentation added, function/classes headers clean?
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Has the `README.md` been updated, or not required?
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Has the `CHANGELOG` been updated?
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Have unit tests been added where needed?
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Any testing not covered by unit tests was done manually by the reviewers.
    - [ ] Reviewer 1
    - [ ] Reviewer 2
- Version ticks in `package.xml`, `CMakeLists.txt` and/or `setup.py` were made.
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- Licensing updates were added, or not required.
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check
- New dependencies added to `requirements.txt`, `setup.py` and `package.xml` - or: not applicable.
    - [ ] Reviewer 1 check
    - [ ] Reviewer 2 check

